### PR TITLE
Adjust chatbox rendering datastorage and display

### DIFF
--- a/client/src/components/Messages.jsx
+++ b/client/src/components/Messages.jsx
@@ -1,7 +1,26 @@
-import useWebSocket from "react-use-websocket";
 import { Box } from "@chakra-ui/react";
+import { get } from "mongoose";
 
 const Messages = ({ lastJsonMessage }) => {
+	async function getMessages() {
+		// chat lastJsonMessage – if it's empty, get the last hour of chat from database
+		// let messages = lastJsonMessage?.chatMessages || [];
+		// if (messages.length === 0) {
+		// get the last hour of chat from database
+		const lastHourOfMessages = await fetch("/api/message/get", {
+			method: "GET",
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+		if (!lastHourOfMessages.ok) throw new Error("Error getting last hour of chat");
+		const data = await lastHourOfMessages.json();
+		console.log(data);
+		// } else {
+		// 	return;
+		// }
+	}
+	// getMessages();
 	const messages = lastJsonMessage?.chatMessages || [];
 	if (lastJsonMessage === null) {
 		return <div>Loading...</div>;

--- a/client/src/components/Messages.jsx
+++ b/client/src/components/Messages.jsx
@@ -1,30 +1,42 @@
 import { Box } from "@chakra-ui/react";
-import { get } from "mongoose";
+import { useState, useEffect } from "react";
 
 const Messages = ({ lastJsonMessage }) => {
+	const [messages, setMessages] = useState([]);
+
 	async function getMessages() {
-		// chat lastJsonMessage – if it's empty, get the last hour of chat from database
-		// let messages = lastJsonMessage?.chatMessages || [];
-		// if (messages.length === 0) {
-		// get the last hour of chat from database
-		const lastHourOfMessages = await fetch("/api/message/get", {
-			method: "GET",
-			headers: {
-				"Content-Type": "application/json",
-			},
-		});
-		if (!lastHourOfMessages.ok) throw new Error("Error getting last hour of chat");
-		const data = await lastHourOfMessages.json();
-		console.log(data);
-		// } else {
-		// 	return;
-		// }
+		try {
+			// get the last hour of chat from database
+			const lastTwentyMessages = await fetch("/api/message/get/lastTwenty", {
+				method: "GET",
+				headers: {
+					"Content-Type": "application/json",
+				},
+			});
+			if (!lastTwentyMessages.ok) throw new Error("Error getting last hour of chat");
+			const data = await lastTwentyMessages.json();
+			console.log(data);
+			return data;
+		} catch (err) {
+			console.log(err);
+		}
 	}
-	// getMessages();
-	const messages = lastJsonMessage?.chatMessages || [];
-	if (lastJsonMessage === null) {
-		return <div>Loading...</div>;
-	}
+
+	useEffect(() => {
+		async function fetchData() {
+			if (!lastJsonMessage || lastJsonMessage.chatMessages.length === 0) {
+				const data = await getMessages();
+				setMessages(data);
+			} else {
+				setMessages((messages) => [
+					...messages,
+					lastJsonMessage.chatMessages[lastJsonMessage.chatMessages.length - 1],
+				]);
+			}
+		}
+
+		fetchData();
+	}, [lastJsonMessage]);
 
 	return (
 		<>

--- a/client/src/components/Messages.jsx
+++ b/client/src/components/Messages.jsx
@@ -1,20 +1,23 @@
-import { Box } from "@chakra-ui/react";
-import { useState, useEffect } from "react";
+import { Box, Text } from "@chakra-ui/react";
+import { useState, useEffect, useRef } from "react";
 
 const Messages = ({ lastJsonMessage }) => {
 	const [messages, setMessages] = useState([]);
+	const [loadMoreState, setLoadMoreState] = useState(false);
+	const scrollableRef = useRef();
 
 	async function getMessages() {
 		try {
 			// get the last hour of chat from database
-			const lastTwentyMessages = await fetch("/api/message/get/lastTwenty", {
+			const mostRecentTwentyMessages = await fetch("/api/message/get/mostRecentTwenty", {
 				method: "GET",
 				headers: {
 					"Content-Type": "application/json",
 				},
 			});
-			if (!lastTwentyMessages.ok) throw new Error("Error getting last hour of chat");
-			const data = await lastTwentyMessages.json();
+			if (!mostRecentTwentyMessages.ok)
+				throw new Error("Error getting last hour of chat");
+			const data = await mostRecentTwentyMessages.json();
 			console.log(data);
 			return data;
 		} catch (err) {
@@ -38,14 +41,54 @@ const Messages = ({ lastJsonMessage }) => {
 		fetchData();
 	}, [lastJsonMessage]);
 
+	const getMoreMessages = async () => {
+		try {
+			setLoadMoreState(true);
+			const lastMessageId = messages[0]._id;
+			const data = await fetch(`/api/message/get/nextTwentyMessages/${lastMessageId}`, {
+				method: "GET",
+				headers: {
+					"Content-Type": "application/json",
+				},
+			});
+			if (!data.ok) throw new Error("Error getting next twenty messages");
+			const json = await data.json();
+			console.log(json);
+			setMessages((messages) => [...json, ...messages]);
+		} catch (err) {
+			console.log(err);
+		}
+	};
+
+	useEffect(() => {
+		// Scroll to the bottom of the chat box
+		if (loadMoreState) {
+			setLoadMoreState(false);
+		} else {
+			scrollableRef.current.scrollTop = scrollableRef.current.scrollHeight;
+		}
+	}, [messages]);
+
 	return (
 		<>
 			<Box
-				style={{
-					border: "1px solid green",
-					minHeight: "2rem",
-				}}
+				border="1px solid green"
+				minHeight="2rem"
+				h="75vh"
+				overflowY="scroll"
+				ref={scrollableRef}
+				display="flex"
+				flexDirection="column"
 			>
+				<Text
+					alignSelf="center"
+					fontSize={12}
+					as="a"
+					cursor="pointer"
+					onClick={getMoreMessages}
+				>
+					Load More...
+				</Text>
 				{messages &&
 					messages.map((message, index) => {
 						const { timestamp, content } = message;

--- a/client/src/pages/WebSocketTest.jsx
+++ b/client/src/pages/WebSocketTest.jsx
@@ -56,22 +56,6 @@ const WebSocketTest = () => {
 		validateToken();
 	}, []);
 
-	async function saveMessageInDb(content, userId) {
-		try {
-			const newMessage = await fetch("/api/message/create", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({ content, userId }),
-			});
-			if (!newMessage.ok) throw new Error("Error saving message");
-			const newMessageObj = await newMessage.json();
-		} catch (err) {
-			console.error(err);
-		}
-	}
-
 	function handleChatMessageChange() {
 		setChatMessage(document.getElementById("chat-message-field").value);
 	}
@@ -90,8 +74,6 @@ const WebSocketTest = () => {
 				content,
 				type: "chatevent",
 			});
-
-			saveMessageInDb(content, userId);
 
 			setChatMessage("");
 		}

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -14,6 +14,10 @@ const messageSchema = new Schema({
 		type: Date,
 		default: Date.now,
 	},
+	timestamp: {
+		type: String,
+		required: true,
+	},
 });
 
 const Message = model("Message", messageSchema);

--- a/server/routes/api/MessageRoutes.js
+++ b/server/routes/api/MessageRoutes.js
@@ -18,16 +18,16 @@ router.post("/create", async (req, res) => {
 	}
 });
 
-// get last hour of messages
-// /api/message/get/lastHour
-router.get("/get/lastHour", async (req, res) => {
+// get last twenty messages
+// /api/message/get/lastTwenty
+router.get("/get/lastTwenty", async (req, res) => {
 	try {
-		const messageData = await Message.find({
-			time: {
-				$gte: new Date(new Date() - 60 * 60 * 1000),
-			},
-		}).populate("userId");
-		res.status(200).json(messageData);
+		const messageData = await Message.find({})
+			.sort({ time: -1 })
+			.limit(20)
+			.populate("userId");
+		const reversedMessages = messageData.sort((a, b) => a.time - b.time);
+		res.status(200).json(reversedMessages);
 	} catch (err) {
 		res.status(400).json(err);
 	}

--- a/server/routes/api/MessageRoutes.js
+++ b/server/routes/api/MessageRoutes.js
@@ -5,10 +5,11 @@ const { Message } = require("../../models");
 // create a message
 router.post("/create", async (req, res) => {
 	try {
-		const { content, userId } = req.body;
+		const { content, userId, timestamp } = req.body;
 		const messageData = await Message.create({
 			content,
 			userId,
+			timestamp,
 		});
 
 		res.status(200).json(messageData);
@@ -18,11 +19,11 @@ router.post("/create", async (req, res) => {
 });
 
 // get last hour of messages
-// /api/message/get/lasthour
-router.get("/get/lasthour", async (req, res) => {
+// /api/message/get/lastHour
+router.get("/get/lastHour", async (req, res) => {
 	try {
 		const messageData = await Message.find({
-			timestamp: {
+			time: {
 				$gte: new Date(new Date() - 60 * 60 * 1000),
 			},
 		}).populate("userId");

--- a/server/routes/api/MessageRoutes.js
+++ b/server/routes/api/MessageRoutes.js
@@ -18,9 +18,9 @@ router.post("/create", async (req, res) => {
 	}
 });
 
-// get last twenty messages
-// /api/message/get/lastTwenty
-router.get("/get/lastTwenty", async (req, res) => {
+// get most recent twenty messages
+// /api/message/get/mostRecentTwenty
+router.get("/get/mostRecentTwenty", async (req, res) => {
 	try {
 		const messageData = await Message.find({})
 			.sort({ time: -1 })
@@ -28,6 +28,30 @@ router.get("/get/lastTwenty", async (req, res) => {
 			.populate("userId");
 		const reversedMessages = messageData.sort((a, b) => a.time - b.time);
 		res.status(200).json(reversedMessages);
+	} catch (err) {
+		res.status(400).json(err);
+	}
+});
+
+// get the next twenty messages
+// /api/message/get/nextTwentyMessages/:lastMessageId
+router.get("/get/nextTwentyMessages/:lastDisplayedMessageId", async (req, res) => {
+	const { lastDisplayedMessageId } = req.params;
+	try {
+		const lastDisplayedMessage = await Message.findById(lastDisplayedMessageId);
+		if (!lastDisplayedMessage) {
+			return res.status(404).json({ message: "Last message not found" });
+		}
+
+		const nextTwentyMessagesData = await Message.find({
+			time: { $lt: lastDisplayedMessage.time },
+		})
+			.sort({ time: -1 })
+			.limit(20)
+			.populate("userId");
+		const nextTwentyMessages = nextTwentyMessagesData.sort((a, b) => a.time - b.time);
+
+		res.status(200).json(nextTwentyMessages);
 	} catch (err) {
 		res.status(400).json(err);
 	}

--- a/server/server.js
+++ b/server/server.js
@@ -12,6 +12,7 @@ const routes = require("./routes");
 const app = express();
 const server = createServer(app);
 const PORT = process.env.PORT || 3001;
+const HOSTPATHFORAPI = process.env.HOSTPATHFORAPI || "http://localhost:3001";
 
 // Websocket setup
 const { WebSocketServer } = require("ws");
@@ -27,9 +28,11 @@ wsServer.on("connection", function (connection) {
 	console.log("Received a new connection");
 	// Store the new connection and handle messages
 	clients[connectionId] = connection;
-	connection.on("message", (message) => handleMessage(message, connectionId, clients));
+	connection.on("message", (message) =>
+		handleMessage(message, connectionId, clients, HOSTPATHFORAPI)
+	);
 	// User disconnected
-	connection.on("close", () => handleDisconnect(connectionId, clients));
+	connection.on("close", () => handleDisconnect(connectionId, clients, HOSTPATHFORAPI));
 });
 
 app.use(express.json());

--- a/server/server.js
+++ b/server/server.js
@@ -28,6 +28,7 @@ wsServer.on("connection", function (connection) {
 	console.log("Received a new connection");
 	// Store the new connection and handle messages
 	clients[connectionId] = connection;
+	// User sent a message, either userevent or a chatevent
 	connection.on("message", (message) =>
 		handleMessage(message, connectionId, clients, HOSTPATHFORAPI)
 	);

--- a/server/utils/serverHelper.js
+++ b/server/utils/serverHelper.js
@@ -20,13 +20,13 @@ async function handleMessage(message, connectionId, clients, HOSTPATHFORAPI) {
 			connections[connectionId] = userId;
 			const content = `${first_name} joined the chat`;
 			chatMessages.push({ timestamp, content, connectionId });
-			saveMessageInDb(content, userId, HOSTPATHFORAPI);
+			saveMessageInDb(content, userId, timestamp, HOSTPATHFORAPI);
 		}
 	} else if (dataFromClient.type === "chatevent") {
 		const { first_name, content, userId } = dataFromClient;
 		const userContent = `${first_name}: ${content}`;
 		chatMessages.push({ timestamp, content: userContent, connectionId });
-		saveMessageInDb(userContent, userId, HOSTPATHFORAPI);
+		saveMessageInDb(userContent, userId, timestamp, HOSTPATHFORAPI);
 	}
 	const json = { chatMessages };
 
@@ -63,14 +63,14 @@ function handleDisconnect(connectionId, clients, HOSTPATHFORAPI) {
 	const json = { type: "userevent" };
 	console.log(userFirstName, " disconnected");
 	chatMessages.push({ timestamp, content });
-	saveMessageInDb(content, userId, HOSTPATHFORAPI);
+	saveMessageInDb(content, userId, timestamp, HOSTPATHFORAPI);
 	json.data = { users, chatMessages };
 	delete clients[connectionId];
 	delete users[userId];
 	broadcastMessage(json);
 }
 
-async function saveMessageInDb(content, userId, HOSTPATHFORAPI) {
+async function saveMessageInDb(content, userId, timestamp, HOSTPATHFORAPI) {
 	// generate the right path to the api endpoint
 	const url = `${HOSTPATHFORAPI}/api/message/create`;
 	try {
@@ -79,11 +79,11 @@ async function saveMessageInDb(content, userId, HOSTPATHFORAPI) {
 			headers: {
 				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ content, userId }),
+			body: JSON.stringify({ content, userId, timestamp }),
 		});
 		if (!newMessage.ok) throw new Error("Error saving message");
 		const newMessageObj = await newMessage.json();
-		console.log("newMessages: ", newMessageObj);
+		console.log(newMessageObj);
 	} catch (err) {
 		console.error(err);
 	}

--- a/server/utils/serverHelper.js
+++ b/server/utils/serverHelper.js
@@ -23,14 +23,12 @@ async function handleMessage(message, connectionId, clients, HOSTPATHFORAPI) {
 			chatMessages.push({ timestamp, content, connectionId });
 			saveMessageInDb(content, userId, timestamp, HOSTPATHFORAPI);
 		}
-		console.log("User joined the chat:", users[dataFromClient.userId]);
 	} else if (dataFromClient.type === "chatevent") {
 		const { first_name, content, userId } = dataFromClient;
 		const userContent = `${first_name}: ${content}`;
 		chatMessages.push({ timestamp, content: userContent, connectionId });
 		saveMessageInDb(userContent, userId, timestamp, HOSTPATHFORAPI);
 	}
-	console.log("Current chatMessages:", chatMessages);
 
 	const json = { chatMessages };
 
@@ -60,9 +58,6 @@ function handleDisconnect(connectionId, clients, HOSTPATHFORAPI) {
 	if (!userFirstName) {
 		return;
 	}
-
-	console.log("User disconnected:", userFirstName);
-	console.log("Current chatMessages:", chatMessages);
 
 	const timestamp = getTimestamp();
 


### PR DESCRIPTION
Okay, so here's what this does:

- I moved the database call to store messages to the backend (had to figure out a pathing system)
- Separated out timestamp (display version of time) and time in database – timestamp for display, time for chronological calculations
- As websocket connection was the only thing persisting the chat log, I added use of database to grab the most recent 20 messages on page load, and then updating using the lastJsonMessage as messages are sent. Want to update to add a caching mechanism for the chat messages as well so that the database doesn't have to be pulled from all the time.
- Added load more button to grab the previous 20 messages at the top of the chatbox
- Adjusted chatbox to be a specific height that scrolls. Added logic to take user to bottom of chatbox on new message being sent. (There is an issue sometimes with it recoiling back up, haven't diagnosed yet)
- There was a consistent issue with userevents (first_name disconnected or first_name connected) not rendering (the former and the latter) or rendering twice (the latter). They appeared to always be in the database, but some sort of synchronicity error is my assumption.
- I adjusted users and connections objects to be maps. This has helped with the above issue, but not fully. 
- I've added some comments, but not a full number.