### PR TITLE
Userevent fixes

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,6 @@
 			"dependencies": {
 				"@chakra-ui/icons": "^2.0.19",
 				"@chakra-ui/react": "^2.7.1",
-				"async-mutex": "^0.4.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-router-dom": "^6.13.0",
@@ -2398,14 +2397,6 @@
 				"es-abstract": "^1.20.4",
 				"es-shim-unscopables": "^1.0.0",
 				"get-intrinsic": "^1.1.3"
-			}
-		},
-		"node_modules/async-mutex": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
-			"integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
-			"dependencies": {
-				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/available-typed-arrays": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@chakra-ui/icons": "^2.0.19",
 				"@chakra-ui/react": "^2.7.1",
+				"async-mutex": "^0.4.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-router-dom": "^6.13.0",
@@ -2397,6 +2398,14 @@
 				"es-abstract": "^1.20.4",
 				"es-shim-unscopables": "^1.0.0",
 				"get-intrinsic": "^1.1.3"
+			}
+		},
+		"node_modules/async-mutex": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+			"integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/available-typed-arrays": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-router-dom": "^6.13.0",
+				"react-textarea-autosize": "^8.5.3",
 				"react-use-websocket": "^4.3.1",
 				"uuid": "^9.0.0"
 			},
@@ -4337,6 +4338,22 @@
 				}
 			}
 		},
+		"node_modules/react-textarea-autosize": {
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz",
+			"integrity": "sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.20.13",
+				"use-composed-ref": "^1.3.0",
+				"use-latest": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
 		"node_modules/react-use-websocket": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/react-use-websocket/-/react-use-websocket-4.3.1.tgz",
@@ -4762,6 +4779,43 @@
 			},
 			"peerDependencies": {
 				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/use-composed-ref": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+			"integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/use-isomorphic-layout-effect": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+			"integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/use-latest": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+			"integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+			"dependencies": {
+				"use-isomorphic-layout-effect": "^1.1.1"
+			},
+			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			},
 			"peerDependenciesMeta": {

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-router-dom": "^6.13.0",
+		"react-textarea-autosize": "^8.5.3",
 		"react-use-websocket": "^4.3.1",
 		"uuid": "^9.0.0"
 	},

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
 	"dependencies": {
 		"@chakra-ui/icons": "^2.0.19",
 		"@chakra-ui/react": "^2.7.1",
+		"async-mutex": "^0.4.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-router-dom": "^6.13.0",

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,6 @@
 	"dependencies": {
 		"@chakra-ui/icons": "^2.0.19",
 		"@chakra-ui/react": "^2.7.1",
-		"async-mutex": "^0.4.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-router-dom": "^6.13.0",

--- a/client/src/components/Messages.jsx
+++ b/client/src/components/Messages.jsx
@@ -9,14 +9,10 @@ const Messages = ({ lastJsonMessage, firstName, mutex }) => {
 
 	// functions to get Messages from the database
 
-	// window.debugMessages = function () {
-	// 	return messages;
-	// };
-
 	// get the most recent twenty messages from the database
 	async function getMessages() {
 		try {
-			// get the last twent messages from the database
+			// get the last twenty messages from the database
 			const mostRecentTwentyMessages = await fetch("/api/message/get/mostRecentTwenty", {
 				method: "GET",
 				headers: {
@@ -68,21 +64,18 @@ const Messages = ({ lastJsonMessage, firstName, mutex }) => {
 	// determine where to get message data from
 	async function fetchData() {
 		await mutex.runExclusive(async () => {
-			if (!lastJsonMessage || lastJsonMessage.chatMessages.length === 0) {
-				console.log("acorn");
+			if (messages.length === 0) {
 				const data = await getMessages();
-
 				console.log("tomato");
 				setMessages(data);
-			} else {
-				console.log(
-					"dingle",
-					lastJsonMessage.chatMessages[lastJsonMessage.chatMessages.length - 1]
-				);
+			} else if (lastJsonMessage) {
+				console.log("dingle");
 				setMessages((messages) => [
 					...messages,
 					lastJsonMessage.chatMessages[lastJsonMessage.chatMessages.length - 1],
 				]);
+			} else {
+				console.log("leg");
 			}
 		});
 	}

--- a/client/src/components/Messages.jsx
+++ b/client/src/components/Messages.jsx
@@ -148,16 +148,20 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 					messages.map((message, index) => {
 						const { timestamp, content } = message;
 						let type;
-						let messageContent;
+						let messageContentNonSplit;
 						let userName;
 						// break content apart by : to style separately
 						if (content.includes(":")) {
-							[userName, messageContent] = content.split(":");
+							[userName, messageContentNonSplit] = content.split(":");
 							type = "chatevent";
 						} else {
 							type = "userevent";
-							messageContent = content;
+							messageContentNonSplit = content;
 						}
+
+						// make sure all linebreaks are rendered
+						const messageContent = messageContentNonSplit.replace(/\n/g, "<br />");
+
 						return (
 							<Flex
 								key={`message${index}`}
@@ -184,9 +188,12 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 											>
 												{userName}:
 											</Text>
-											<Text fontSize="md" px={8} wordBreak="break-word">
-												{messageContent}
-											</Text>
+											<Text
+												fontSize="md"
+												px={8}
+												wordBreak="break-word"
+												dangerouslySetInnerHTML={{ __html: messageContent }}
+											/>
 										</Flex>
 										<Text fontSize="2xs" color="gray.600">
 											{timestamp}
@@ -199,9 +206,11 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 										alignItems="center"
 										fontSize="2xs"
 									>
-										<Text>
-											{messageContent} - {timestamp}
-										</Text>
+										<Text
+											dangerouslySetInnerHTML={{
+												__html: `${messageContent} - ${timestamp}`,
+											}}
+										/>
 									</Flex>
 								)}
 							</Flex>

--- a/client/src/components/Messages.jsx
+++ b/client/src/components/Messages.jsx
@@ -97,7 +97,7 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 				overflowX="hidden"
 				css={{
 					"&::-webkit-scrollbar": {
-						width: 8,
+						width: 10,
 					},
 					"&::-webkit-scrollbar-track": {
 						backgroundColor: "transparent",
@@ -189,7 +189,12 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 											>
 												{userName}:
 											</Text>
-											<Text fontSize="md" px={4} wordBreak="break-word" whiteSpace="pre">
+											<Text
+												fontSize="md"
+												px={4}
+												wordBreak="break-word"
+												whiteSpace="pre-wrap"
+											>
 												{messageContent}
 											</Text>
 										</Flex>

--- a/client/src/components/Messages.jsx
+++ b/client/src/components/Messages.jsx
@@ -94,6 +94,23 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 			<Box
 				minHeight="2rem"
 				overflowY="scroll"
+				css={{
+					"&::-webkit-scrollbar": {
+						width: 8,
+					},
+					"&::-webkit-scrollbar-track": {
+						backgroundColor: "transparent",
+					},
+					"&::-webkit-scrollbar-thumb": {
+						borderRadius: 8,
+						backgroundColor: "transparent",
+						border: "none",
+						transition: "background-color 0.2s", // Add transition for fading in
+					},
+					"&:hover::-webkit-scrollbar-thumb": {
+						backgroundColor: "gray", // Fade-in effect on hover
+					},
+				}}
 				ref={scrollableRef}
 				display="flex"
 				flexDirection="column"
@@ -103,9 +120,6 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 				boxShadow="inner"
 				borderRadius={8}
 				bg="gray.200"
-				css={{
-					scrollbarGutter: "none",
-				}}
 			>
 				{loadMoreState ? (
 					<Flex

--- a/client/src/components/Messages.jsx
+++ b/client/src/components/Messages.jsx
@@ -156,7 +156,7 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 							const firstColonIndex = content.indexOf(":");
 
 							userName = content.slice(0, firstColonIndex);
-							messageContent = content.slice(firstColonIndex + 1).split("\n");
+							messageContent = content.slice(firstColonIndex + 1);
 							type = "chatevent";
 						} else {
 							type = "userevent";
@@ -190,14 +190,7 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 												{userName}:
 											</Text>
 											<Text fontSize="md" px={4} wordBreak="break-word" whiteSpace="pre">
-												{messageContent.map((line, index) => {
-													return (
-														<Fragment key={`line${index}`}>
-															{line}
-															<br />
-														</Fragment>
-													);
-												})}
+												{messageContent}
 											</Text>
 										</Flex>
 										<Text fontSize="2xs" color="gray.600">

--- a/client/src/components/Messages.jsx
+++ b/client/src/components/Messages.jsx
@@ -103,12 +103,11 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 					},
 					"&::-webkit-scrollbar-thumb": {
 						borderRadius: 8,
-						backgroundColor: "transparent",
 						border: "none",
-						transition: "background-color 0.2s", // Add transition for fading in
+						background: "#aaa",
 					},
-					"&:hover::-webkit-scrollbar-thumb": {
-						backgroundColor: "gray", // Fade-in effect on hover
+					"&::-webkit-scrollbar-thumb:hover": {
+						background: "#999",
 					},
 				}}
 				ref={scrollableRef}

--- a/client/src/components/Messages.jsx
+++ b/client/src/components/Messages.jsx
@@ -1,5 +1,5 @@
 import { Box, Text, Flex } from "@chakra-ui/react";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, Fragment } from "react";
 import Loader from "./Loader";
 
 const Messages = ({ lastJsonMessage, firstName }) => {
@@ -94,6 +94,7 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 			<Box
 				minHeight="2rem"
 				overflowY="scroll"
+				overflowX="hidden"
 				css={{
 					"&::-webkit-scrollbar": {
 						width: 8,
@@ -148,19 +149,19 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 					messages.map((message, index) => {
 						const { timestamp, content } = message;
 						let type;
-						let messageContentNonSplit;
+						let messageContent;
 						let userName;
 						// break content apart by : to style separately
 						if (content.includes(":")) {
-							[userName, messageContentNonSplit] = content.split(":");
+							const firstColonIndex = content.indexOf(":");
+
+							userName = content.slice(0, firstColonIndex);
+							messageContent = content.slice(firstColonIndex + 1).split("\n");
 							type = "chatevent";
 						} else {
 							type = "userevent";
-							messageContentNonSplit = content;
+							messageContent = content;
 						}
-
-						// make sure all linebreaks are rendered
-						const messageContent = messageContentNonSplit.replace(/\n/g, "<br />");
 
 						return (
 							<Flex
@@ -175,7 +176,7 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 								color="black"
 								borderRadius={8}
 								px={4}
-								py={4}
+								py={3}
 								boxShadow="sm"
 							>
 								{type === "chatevent" ? (
@@ -188,12 +189,16 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 											>
 												{userName}:
 											</Text>
-											<Text
-												fontSize="md"
-												px={8}
-												wordBreak="break-word"
-												dangerouslySetInnerHTML={{ __html: messageContent }}
-											/>
+											<Text fontSize="md" px={4} wordBreak="break-word" whiteSpace="pre">
+												{messageContent.map((line, index) => {
+													return (
+														<Fragment key={`line${index}`}>
+															{line}
+															<br />
+														</Fragment>
+													);
+												})}
+											</Text>
 										</Flex>
 										<Text fontSize="2xs" color="gray.600">
 											{timestamp}
@@ -206,11 +211,9 @@ const Messages = ({ lastJsonMessage, firstName }) => {
 										alignItems="center"
 										fontSize="2xs"
 									>
-										<Text
-											dangerouslySetInnerHTML={{
-												__html: `${messageContent} - ${timestamp}`,
-											}}
-										/>
+										<Text>
+											{messageContent} - {timestamp}
+										</Text>
 									</Flex>
 								)}
 							</Flex>

--- a/client/src/components/ResizeTextarea.jsx
+++ b/client/src/components/ResizeTextarea.jsx
@@ -1,0 +1,21 @@
+import { forwardRef, useState } from "react";
+import { Textarea } from "@chakra-ui/react";
+import ResizeTextarea from "react-textarea-autosize";
+
+const AutoResizeTextarea = forwardRef(
+	({ textareaInputValue, setTextareaInputValue, ...props }, ref) => {
+		return (
+			<Textarea
+				ref={ref}
+				as={ResizeTextarea}
+				value={textareaInputValue}
+				onChange={(event) => {
+					setTextareaInputValue(event.target.value);
+				}}
+				{...props}
+			/>
+		);
+	}
+);
+
+export default AutoResizeTextarea;

--- a/client/src/components/ResizeTextarea.jsx
+++ b/client/src/components/ResizeTextarea.jsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState } from "react";
+import { forwardRef } from "react";
 import { Textarea } from "@chakra-ui/react";
 import ResizeTextarea from "react-textarea-autosize";
 

--- a/client/src/pages/GlobalChat.jsx
+++ b/client/src/pages/GlobalChat.jsx
@@ -1,8 +1,19 @@
 import { useEffect, useState, useRef } from "react";
 import useWebSocket from "react-use-websocket";
-import { Box, Flex, Heading } from "@chakra-ui/react";
+import {
+	Box,
+	Flex,
+	Heading,
+	Drawer,
+	DrawerOverlay,
+	DrawerHeader,
+	DrawerBody,
+	DrawerContent,
+	useDisclosure,
+} from "@chakra-ui/react";
 import Messages from "../components/Messages";
 import Header from "../components/Header";
+import BrandButton from "../components/BrandButton";
 import AutoResizeTextarea from "../components/ResizeTextarea";
 import { validateToken } from "../utils/auth";
 
@@ -14,6 +25,8 @@ const GlobalChat = () => {
 	const [firstName, setFirstName] = useState("");
 	const [userId, setUserId] = useState("");
 	const [isButtonHovered, setIsButtonHovered] = useState(false);
+	const [connectedUsers, setConnectedUsers] = useState([]);
+	const { isOpen, onOpen, onClose } = useDisclosure();
 
 	// useRef declarations
 	const chatTextarea = useRef(null);
@@ -33,6 +46,13 @@ const GlobalChat = () => {
 			return true;
 		},
 	});
+
+	useEffect(() => {
+		if (lastJsonMessage) {
+			setConnectedUsers(lastJsonMessage.users);
+			console.log(lastJsonMessage.users);
+		}
+	}, [lastJsonMessage]);
 
 	// Send message to server
 	const handleSendMessage = () => {
@@ -97,6 +117,30 @@ const GlobalChat = () => {
 		>
 			<Header />
 			<Heading my={5}>Chat</Heading>
+			<BrandButton onClick={onOpen}>Online Users</BrandButton>
+			<Drawer isOpen={isOpen} placement="left" onClose={onClose}>
+				<DrawerOverlay />
+				<DrawerContent>
+					<DrawerHeader>
+						<Flex alignItems="center" justifyContent="space-between">
+							<Heading as="h3" size="md">
+								Online Users
+							</Heading>
+							<Box ml={5} fontSize="md" onClick={onClose} cursor="pointer">
+								X
+							</Box>
+						</Flex>
+					</DrawerHeader>
+					<DrawerBody>
+						{connectedUsers.map((user) => (
+							<Flex alignItems="center">
+								<Box w="10px" h="10px" borderRadius="50%" bgColor="green.400" mr={2} />
+								{user}
+							</Flex>
+						))}
+					</DrawerBody>
+				</DrawerContent>
+			</Drawer>
 			<Flex
 				bgColor="white"
 				w="90%"

--- a/client/src/pages/GlobalChat.jsx
+++ b/client/src/pages/GlobalChat.jsx
@@ -1,15 +1,16 @@
 import { useEffect, useState, useRef, forwardRef } from "react";
 import useWebSocket from "react-use-websocket";
-import { Box, Textarea, Flex, Heading } from "@chakra-ui/react";
+import { Box, Flex, Heading } from "@chakra-ui/react";
 import Messages from "../components/Messages";
 import Header from "../components/Header";
-import ResizeTextarea from "react-textarea-autosize";
+import AutoResizeTextarea from "../components/ResizeTextarea";
 import { validateToken } from "../utils/auth";
 
 const WS_URL = "ws://127.0.0.1:3001";
 
 const GlobalChat = () => {
 	// State declarations
+	const [textareaInputValue, setTextareaInputValue] = useState("");
 	const [firstName, setFirstName] = useState("");
 	const [userId, setUserId] = useState("");
 	const [isButtonHovered, setIsButtonHovered] = useState(false);
@@ -33,19 +34,14 @@ const GlobalChat = () => {
 		},
 	});
 
-	// Custom Components
-	const AutoResizeTextarea = forwardRef((props, ref) => {
-		return <Textarea ref={ref} as={ResizeTextarea} autoFocus {...props} />;
-	});
-
 	// Send message to server
 	const handleSendMessage = () => {
 		if (readyState !== 1) {
 			console.log("WebSocket not connected");
-		} else if (!chatTextarea.current.value) {
+		} else if (!textareaInputValue) {
 			console.log("No message to send");
 		} else {
-			const content = chatTextarea.current.value;
+			const content = textareaInputValue;
 			sendJsonMessage({
 				first_name: firstName,
 				userId: userId,
@@ -53,7 +49,7 @@ const GlobalChat = () => {
 				type: "chatevent",
 			});
 
-			chatTextarea.current.value = "";
+			setTextareaInputValue("");
 		}
 	};
 
@@ -117,6 +113,8 @@ const GlobalChat = () => {
 				<Flex flexDirection="row" boxShadow="lg" borderRadius={8}>
 					<AutoResizeTextarea
 						ref={chatTextarea}
+						textareaInputValue={textareaInputValue}
+						setTextareaInputValue={setTextareaInputValue}
 						onKeyDown={(event) => {
 							if (event.key === "Enter" && !event.shiftKey) {
 								event.preventDefault();

--- a/client/src/pages/GlobalChat.jsx
+++ b/client/src/pages/GlobalChat.jsx
@@ -1,6 +1,5 @@
-import { useEffect, useState, useRef, useMemo } from "react";
+import { useEffect, useState, useRef } from "react";
 import useWebSocket from "react-use-websocket";
-import { Mutex } from "async-mutex";
 import {
 	Box,
 	Flex,
@@ -17,6 +16,7 @@ import Header from "../components/Header";
 import BrandButton from "../components/BrandButton";
 import AutoResizeTextarea from "../components/ResizeTextarea";
 import { validateToken } from "../utils/auth";
+import { getMessages } from "../utils/messageHelpers";
 
 const WS_URL = "ws://127.0.0.1:3001";
 
@@ -25,10 +25,10 @@ const GlobalChat = () => {
 	const [textareaInputValue, setTextareaInputValue] = useState("");
 	const [firstName, setFirstName] = useState("");
 	const [userId, setUserId] = useState("");
+	const [messages, setMessages] = useState([]);
 	const [isButtonHovered, setIsButtonHovered] = useState(false);
 	const [connectedUsers, setConnectedUsers] = useState([]);
 	const { isOpen, onOpen, onClose } = useDisclosure();
-	const mutex = useMemo(() => new Mutex(), []);
 
 	// useRef declarations
 	const chatTextarea = useRef(null);
@@ -52,7 +52,6 @@ const GlobalChat = () => {
 	useEffect(() => {
 		if (lastJsonMessage) {
 			setConnectedUsers(lastJsonMessage.users);
-			console.log(lastJsonMessage.users);
 		}
 	}, [lastJsonMessage]);
 
@@ -91,6 +90,9 @@ const GlobalChat = () => {
 			const { firstName, userId } = await validateToken();
 			setFirstName(firstName);
 			setUserId(userId);
+
+			const data = await getMessages();
+			setMessages(data);
 
 			sendJsonMessage({
 				first_name: firstName,
@@ -155,7 +157,12 @@ const GlobalChat = () => {
 				justifyContent="space-between"
 				boxShadow="xl"
 			>
-				<Messages lastJsonMessage={lastJsonMessage} firstName={firstName} mutex={mutex} />
+				<Messages
+					lastJsonMessage={lastJsonMessage}
+					firstName={firstName}
+					messages={messages}
+					setMessages={setMessages}
+				/>
 				<Flex flexDirection="row" boxShadow="lg" borderRadius={8}>
 					<AutoResizeTextarea
 						ref={chatTextarea}

--- a/client/src/pages/GlobalChat.jsx
+++ b/client/src/pages/GlobalChat.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, forwardRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import useWebSocket from "react-use-websocket";
 import { Box, Flex, Heading } from "@chakra-ui/react";
 import Messages from "../components/Messages";

--- a/client/src/pages/GlobalChat.jsx
+++ b/client/src/pages/GlobalChat.jsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useMemo } from "react";
 import useWebSocket from "react-use-websocket";
+import { Mutex } from "async-mutex";
 import {
 	Box,
 	Flex,
@@ -27,6 +28,7 @@ const GlobalChat = () => {
 	const [isButtonHovered, setIsButtonHovered] = useState(false);
 	const [connectedUsers, setConnectedUsers] = useState([]);
 	const { isOpen, onOpen, onClose } = useDisclosure();
+	const mutex = useMemo(() => new Mutex(), []);
 
 	// useRef declarations
 	const chatTextarea = useRef(null);
@@ -133,7 +135,7 @@ const GlobalChat = () => {
 					</DrawerHeader>
 					<DrawerBody>
 						{connectedUsers.map((user) => (
-							<Flex alignItems="center">
+							<Flex key={user} alignItems="center">
 								<Box w="10px" h="10px" borderRadius="50%" bgColor="green.400" mr={2} />
 								{user}
 							</Flex>
@@ -153,7 +155,7 @@ const GlobalChat = () => {
 				justifyContent="space-between"
 				boxShadow="xl"
 			>
-				<Messages lastJsonMessage={lastJsonMessage} firstName={firstName} />
+				<Messages lastJsonMessage={lastJsonMessage} firstName={firstName} mutex={mutex} />
 				<Flex flexDirection="row" boxShadow="lg" borderRadius={8}>
 					<AutoResizeTextarea
 						ref={chatTextarea}

--- a/client/src/pages/GlobalChat.jsx
+++ b/client/src/pages/GlobalChat.jsx
@@ -1,8 +1,9 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, forwardRef } from "react";
 import useWebSocket from "react-use-websocket";
 import { Box, Textarea, Flex, Heading } from "@chakra-ui/react";
 import Messages from "../components/Messages";
 import Header from "../components/Header";
+import ResizeTextarea from "react-textarea-autosize";
 import { validateToken } from "../utils/auth";
 
 const WS_URL = "ws://127.0.0.1:3001";
@@ -11,7 +12,6 @@ const GlobalChat = () => {
 	// State declarations
 	const [firstName, setFirstName] = useState("");
 	const [userId, setUserId] = useState("");
-	const [chatMessage, setChatMessage] = useState("");
 	const [isButtonHovered, setIsButtonHovered] = useState(false);
 
 	// useRef declarations
@@ -33,25 +33,19 @@ const GlobalChat = () => {
 		},
 	});
 
-	// Helper Functions
-
-	// Event Handlers
-	const handleTextareaValueChange = () => {
-		// Update height of textarea
-		chatTextarea.current.style.height = "auto";
-		chatTextarea.current.style.height = `${chatTextarea.current.scrollHeight}px`;
-		// Update chatMessage state
-		setChatMessage(chatTextarea.current.value);
-	};
+	// Custom Components
+	const AutoResizeTextarea = forwardRef((props, ref) => {
+		return <Textarea ref={ref} as={ResizeTextarea} autoFocus {...props} />;
+	});
 
 	// Send message to server
 	const handleSendMessage = () => {
 		if (readyState !== 1) {
 			console.log("WebSocket not connected");
-		} else if (!chatMessage) {
+		} else if (!chatTextarea.current.value) {
 			console.log("No message to send");
 		} else {
-			const content = chatMessage;
+			const content = chatTextarea.current.value;
 			sendJsonMessage({
 				first_name: firstName,
 				userId: userId,
@@ -59,7 +53,7 @@ const GlobalChat = () => {
 				type: "chatevent",
 			});
 
-			setChatMessage("");
+			chatTextarea.current.value = "";
 		}
 	};
 
@@ -121,10 +115,8 @@ const GlobalChat = () => {
 			>
 				<Messages lastJsonMessage={lastJsonMessage} firstName={firstName} />
 				<Flex flexDirection="row" boxShadow="lg" borderRadius={8}>
-					<Textarea
+					<AutoResizeTextarea
 						ref={chatTextarea}
-						onInput={handleTextareaValueChange}
-						value={chatMessage}
 						onKeyDown={(event) => {
 							if (event.key === "Enter" && !event.shiftKey) {
 								event.preventDefault();

--- a/client/src/pages/GlobalChat.jsx
+++ b/client/src/pages/GlobalChat.jsx
@@ -139,6 +139,22 @@ const GlobalChat = () => {
 						_hover={{
 							boxShadow: "none",
 						}}
+						css={{
+							"&::-webkit-scrollbar": {
+								width: 8,
+							},
+							"&::-webkit-scrollbar-track": {
+								backgroundColor: "transparent",
+							},
+							"&::-webkit-scrollbar-thumb": {
+								borderRadius: 8,
+								border: "none",
+								background: "#aaa",
+							},
+							"&::-webkit-scrollbar-thumb:hover": {
+								background: "#999",
+							},
+						}}
 					/>
 					<Box
 						as="button"

--- a/client/src/pages/GlobalChat.jsx
+++ b/client/src/pages/GlobalChat.jsx
@@ -19,16 +19,18 @@ const GlobalChat = () => {
 
 	// WebSocket Hook declarations
 	const { sendJsonMessage, readyState, lastJsonMessage } = useWebSocket(WS_URL, {
-		onOpen: () => {
-			console.log("WebSocket connection established");
-		},
-		onClose: () => {
-			console.log("WebSocket connection closed");
-		},
-		// Will attempt to reconnect on all close events, such as server shutting down
+		onOpen: () => console.log("WebSocket connection opened"),
+		onClose: () => console.log("WebSocket connection closed"),
 		share: true,
 		retryOnError: true,
-		shouldReconnect: () => true,
+		// set reconnect logic to attempt reconnect once every 3 seconds if connection fails, and is not intentional by the client
+		shouldReconnect: (closeEvent) => {
+			if (closeEvent.code === 1000) {
+				return false;
+			}
+			console.log("WebSocket connection failed, retrying in 3 seconds");
+			return true;
+		},
 	});
 
 	// Helper Functions

--- a/client/src/pages/GlobalChat.jsx
+++ b/client/src/pages/GlobalChat.jsx
@@ -79,6 +79,7 @@ const GlobalChat = () => {
 			const { firstName, userId } = await validateToken();
 			setFirstName(firstName);
 			setUserId(userId);
+
 			sendJsonMessage({
 				first_name: firstName,
 				userId: userId,
@@ -86,8 +87,14 @@ const GlobalChat = () => {
 				type: "userevent",
 			});
 		};
-		validateAndExtract();
-	}, []);
+
+		// Check WebSocket connection state before sending the message
+		if (readyState === 1) {
+			validateAndExtract();
+		} else {
+			console.log("WebSocket not connected");
+		}
+	}, [readyState]);
 
 	return (
 		<Box

--- a/client/src/utils/messageHelpers.js
+++ b/client/src/utils/messageHelpers.js
@@ -1,0 +1,42 @@
+// get the most recent twenty messages from the database
+export const getMessages = async () => {
+	try {
+		// get the last twenty messages from the database
+		const mostRecentTwentyMessages = await fetch("/api/message/get/mostRecentTwenty", {
+			method: "GET",
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+		if (!mostRecentTwentyMessages.ok)
+			throw new Error("Error getting last twenty messages");
+		const data = await mostRecentTwentyMessages.json();
+		return data;
+	} catch (err) {
+		console.log(err);
+	}
+};
+
+// get the next twenty messages from the database
+export const getMoreMessages = async (messages, setMessages) => {
+	try {
+		// get the message Id for the last message in the chat box
+		const lastMessageId = messages[0]._id;
+		// get the next twenty messages from the database, given the last message
+		const nextTwentyMessages = await fetch(
+			`/api/message/get/nextTwentyMessages/${lastMessageId}`,
+			{
+				method: "GET",
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		);
+		if (!nextTwentyMessages.ok) throw new Error("Error getting next twenty messages");
+		const data = await nextTwentyMessages.json();
+		// update state with the new messages
+		setMessages((messages) => [...data, ...messages]);
+	} catch (err) {
+		console.log(err);
+	}
+};

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"description": "",
 	"main": "index.js",
 	"scripts": {
+		"build": "cd client && npm run build",
 		"install": "concurrently \"cd client && npm install\" \"cd server && npm install\"",
 		"dev": "concurrently \"cd client && npm run dev\" \"cd server && npm run watch\""
 	},

--- a/server/routes/api/MessageRoutes.js
+++ b/server/routes/api/MessageRoutes.js
@@ -24,7 +24,7 @@ router.get("/get/mostRecentTwenty", async (req, res) => {
 	try {
 		const messageData = await Message.find({})
 			.sort({ time: -1 })
-			.limit(20)
+			.limit(3)
 			.populate("userId");
 		const reversedMessages = messageData.sort((a, b) => a.time - b.time);
 		res.status(200).json(reversedMessages);

--- a/server/routes/api/MessageRoutes.js
+++ b/server/routes/api/MessageRoutes.js
@@ -24,7 +24,7 @@ router.get("/get/mostRecentTwenty", async (req, res) => {
 	try {
 		const messageData = await Message.find({})
 			.sort({ time: -1 })
-			.limit(3)
+			.limit(20)
 			.populate("userId");
 		const reversedMessages = messageData.sort((a, b) => a.time - b.time);
 		res.status(200).json(reversedMessages);

--- a/server/utils/serverHelper.js
+++ b/server/utils/serverHelper.js
@@ -17,7 +17,10 @@ async function handleMessage(message, connectionId, clients, HOSTPATHFORAPI) {
 	const dataFromClient = JSON.parse(message.toString());
 	const timestamp = getTimestamp();
 
-	if (JSON.stringify(dataFromClient) === JSON.stringify(lastReceivedMessage)) {
+	if (
+		JSON.stringify(dataFromClient) === JSON.stringify(lastReceivedMessage) &&
+		dataFromClient.type === "userevent"
+	) {
 		console.log("Identical message received, ignoring.");
 		return;
 	}

--- a/server/utils/serverHelper.js
+++ b/server/utils/serverHelper.js
@@ -91,7 +91,6 @@ function broadcastMessage(json, clients) {
 	for (const connectionId in clients) {
 		const client = clients[connectionId];
 		if (client.readyState === WebSocket.OPEN) {
-			console.log(data);
 			client.send(data);
 		}
 	}

--- a/server/utils/serverHelper.js
+++ b/server/utils/serverHelper.js
@@ -82,6 +82,10 @@ function handleDisconnect(connectionId, clients, HOSTPATHFORAPI) {
 
 // broadcast message to all connected clients
 function broadcastMessage(json, clients) {
+	const usersNamesArr = Array.from(users.values());
+	json.users = usersNamesArr.map((user) => user.first_name);
+	console.log(json.users);
+
 	// convert json to string
 	const data = JSON.stringify(json);
 	// loop through clients object to send data to each client

--- a/server/utils/serverHelper.js
+++ b/server/utils/serverHelper.js
@@ -84,7 +84,6 @@ function handleDisconnect(connectionId, clients, HOSTPATHFORAPI) {
 function broadcastMessage(json, clients) {
 	const usersNamesArr = Array.from(users.values());
 	json.users = usersNamesArr.map((user) => user.first_name);
-	console.log(json.users);
 
 	// convert json to string
 	const data = JSON.stringify(json);
@@ -92,6 +91,7 @@ function broadcastMessage(json, clients) {
 	for (const connectionId in clients) {
 		const client = clients[connectionId];
 		if (client.readyState === WebSocket.OPEN) {
+			console.log(data);
 			client.send(data);
 		}
 	}


### PR DESCRIPTION
Okay, this is a big one.

First, I added logic to protect the userevent chatmessages from rendering twice unintentionally (if it sent the identical message twice). I also added better reconnect handling to the websocket server based on recommendations found online.

Then bug testing got hard, and I did some styling. A few commits later, what we've ended up with is a scrollbar that shows up only when messages are hidden. It also removes the track. For both the textarea and the chat messages window.

I also changed the text input to a textarea. After a significant amount of fighting, added a new package to handle for autoresizing (using ideas found in the github forum for Chakra UI) to set a specific amount of height that the textarea could size to, before it starts scrolling, while maintaining focus after every character added (this really got me for a second). I also made sure that the text in the Messages component renders with the proper linebreaks, consecutive spaces, etc.

I was facing an issue where the user who logged in sometimes did not see their own join message, though other users would. This led me to assume (with some guidance) that there was a race condition. Before I could get second eyes, I then distracted to add another feature that renders the connected Users onto a Chakra UI drawer on the page by passing the users Map (as an array of their first names) to the front end with every broadcast.

Dealing with the race condition was HARD. After a million console.logs, the help of a compiler engineer, a failed attempt at using Mutex, we found the actual race and adjusted the code to never have the race in the first place. I also cleaned up the code in the process of doing this by creating a utility file for message helper functions. Now, when connecting, post-validation, you load old messages from the database BEFORE it sends the new join message, which is handled separately by a different function that the database call.

OH MAN phewwwww. 